### PR TITLE
Feat: read a http request from tcp connection (create a http::Client)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: maurodri <maurodri@student.42.fr>          +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/07/15 17:53:38 by maurodri          #+#    #+#              #
-#    Updated: 2025/08/27 16:50:26 by maurodri         ###   ########.fr        #
+#    Updated: 2025/08/27 17:55:57 by maurodri         ###   ########.fr        #
 #                                                                              #
 #******************************************************************************#
 
@@ -28,7 +28,8 @@ UTIL_FILES := $(addprefix $(UTIL_DIR)/, BufferedReader.cpp\
 					BufferedWriter.cpp)
 HTTP_FILES := $(addprefix $(HTTP_DIR)/, Request.cpp \
 					Headers.cpp \
-					Body.cpp)
+					Body.cpp \
+					Client.cpp)
 MODULE_FILES := $(CONN_FILES) \
 	$(UTIL_FILES) \
 	$(HTTP_FILES) # add other module files here

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@
         ```
   - 404 response
     - create a 404 response
-  - create a HttpClient class that inherits from TcpClient and has a Request and Response
+  - [ ] create a HttpClient class that inherits from TcpClient and has a Request and Response
     - Request and Response are initially empty
     - we parse Request using Request.readFromTcpClient()
     - generate some Response and send it back to client

--- a/README.md
+++ b/README.md
@@ -104,14 +104,14 @@
   - setup tests for http module
     - test response based on method that return response as a string
     - [X] test request based on method that accepts fd and create a request object
-  - get Request with headers
+  - [X] get Request with headers
     - parse a get request containing some headers
       - ```
            GET / HTTP/1.1
            Connection: close
            Host: localhost
         ```
-    - parse a post request with a body
+    - [X] parse a post request with a body
       - ```
            POST / HTTP/1.1
            Connection: close
@@ -122,13 +122,14 @@
         ```
   - 404 response
     - create a 404 response
-  - [ ] create a HttpClient class that inherits from TcpClient and has a Request and Response
+  - [X] create a HttpClient class that inherits from TcpClient and has a Request and Response
     - Request and Response are initially empty
     - we parse Request using Request.readFromTcpClient()
     - generate some Response and send it back to client
     - next message from client overwrites previous Request
       - maybe we will need to clear first before reusing
-    - provide a public method to return the state of parsing and the current request 
+    - provide a public method to return the state of parsing and the current request
+  - receive a request from browser
 - Connection Handling
   - [X] create folder for connection module
   - tcp
@@ -141,6 +142,7 @@
     - [X] handle multiple concurrent connections
     - [X] use epoll or something alike
     - handle todos left on EventLoop
+    - fix issues of buffered reader: a read may contain several \r\n in a single read
   - file
     - create a class to handle file opening
   - cgi

--- a/src/conn/EventLoop.hpp
+++ b/src/conn/EventLoop.hpp
@@ -6,7 +6,7 @@
 //   By: maurodri <maurodri@student.42sp...>        +#+  +:+       +#+        //
 //                                                +#+#+#+#+#+   +#+           //
 //   Created: 2025/08/26 16:57:28 by maurodri          #+#    #+#             //
-//   Updated: 2025/08/26 22:31:23 by maurodri         ###   ########.fr       //
+//   Updated: 2025/08/27 18:11:59 by maurodri         ###   ########.fr       //
 //                                                                            //
 // ************************************************************************** //
 
@@ -16,6 +16,7 @@
 #include <map>
 #include "TcpServer.hpp"
 #include "TcpClient.hpp"
+#include "Client.hpp"
 #include <sys/epoll.h>
 
 # define MAX_EVENTS 6
@@ -27,7 +28,7 @@ namespace conn
 	{
 		int epollFd;
 		std::map<int, TcpServer*> servers;
-		std::map<int, TcpClient*> clients;
+		std::map<int, http::Client*> clients;
 
 	public:
 
@@ -37,15 +38,15 @@ namespace conn
 		virtual ~EventLoop();
 
 		bool subscribeTcpServer(TcpServer *tcpServer);
-		bool subscribeTcpClient(int fd);
+		bool subscribeHttpClient(int fd);
 		bool loop(void);
 		bool isOk() const;
-		bool unsubscribeTcpClient(TcpClient *client , struct epoll_event *clientEvent);
+		bool unsubscribeHttpClient(http::Client *client , struct epoll_event *clientEvent);
 
 	};
 
 	typedef std::map<int, TcpServer*>::iterator MapServerIterator;
-	typedef std::map<int, TcpClient*>::iterator MapClientIterator;
+	typedef std::map<int, http::Client*>::iterator MapClientIterator;
 }
 
 #endif

--- a/src/conn/TcpClient.hpp
+++ b/src/conn/TcpClient.hpp
@@ -6,7 +6,7 @@
 //   By: maurodri <maurodri@student.42.fr>          +#+  +:+       +#+        //
 //                                                +#+#+#+#+#+   +#+           //
 //   Created: 2025/08/25 21:44:02 by maurodri          #+#    #+#             //
-//   Updated: 2025/08/26 21:30:12 by maurodri         ###   ########.fr       //
+//   Updated: 2025/08/27 18:37:06 by maurodri         ###   ########.fr       //
 //                                                                            //
 // ************************************************************************** //
 
@@ -24,18 +24,20 @@ namespace conn {
 		BufferedWriter writer;
 		TcpClient();
 
-	public:
+	protected:
 		TcpClient(int clientFd);
 		TcpClient(const TcpClient &other);
 		virtual TcpClient &operator=(const TcpClient &other);
 		virtual ~TcpClient();
 
+		std::string getMessageToSend() const;
+
+	public:
+		WriteState getWriterState() const;
+		void setMessageToSend(std::string message);
+		std::pair<WriteState, char*> flushMessage();
 		std::pair<ReadState, char *> read(size_t length);
 		std::pair<ReadState, char *> readlineCrlf();
-		void setMessageToSend(std::string message);
-		WriteState getWriterState() const;
-		std::string getMessageToSend() const;
-		std::pair<WriteState, char*> flushMessage();
 	};
 }
 

--- a/src/http/Body.cpp
+++ b/src/http/Body.cpp
@@ -6,7 +6,7 @@
 /*   By: vcarrara <vcarrara@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/27 13:47:36 by vcarrara          #+#    #+#             */
-/*   Updated: 2025/08/27 14:25:32 by vcarrara         ###   ########.fr       */
+//   Updated: 2025/08/27 18:51:38 by maurodri         ###   ########.fr       //
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,5 +47,9 @@ namespace http {
 	// Return content size
 	size_t Body::size(void) const {
 		return _content.size();
+	}
+
+	void Body::clear(void) {
+		_content = "";
 	}
 }

--- a/src/http/Body.hpp
+++ b/src/http/Body.hpp
@@ -6,7 +6,7 @@
 /*   By: vcarrara <vcarrara@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/27 13:47:30 by vcarrara          #+#    #+#             */
-/*   Updated: 2025/08/27 14:11:35 by vcarrara         ###   ########.fr       */
+//   Updated: 2025/08/27 18:50:58 by maurodri         ###   ########.fr       //
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,6 +28,7 @@ namespace http {
 
 			std::string str(void) const;
 			size_t size(void) const;
+			void clear(void);
 
 		private:
 			std::string _content;

--- a/src/http/Client.cpp
+++ b/src/http/Client.cpp
@@ -6,7 +6,7 @@
 //   By: maurodri <maurodri@student.42sp...>        +#+  +:+       +#+        //
 //                                                +#+#+#+#+#+   +#+           //
 //   Created: 2025/08/27 17:43:15 by maurodri          #+#    #+#             //
-//   Updated: 2025/08/27 21:34:52 by maurodri         ###   ########.fr       //
+//   Updated: 2025/08/28 20:25:56 by maurodri         ###   ########.fr       //
 //                                                                            //
 // ************************************************************************** //
 
@@ -34,6 +34,14 @@ namespace http {
 		//TODO
 
 		return *this;
+	}
+
+	Client &Client::operator=(const conn::TcpClient &other) {
+            if (this == &other) {
+                return *this;
+            }
+			conn::TcpClient::operator=(other);
+			return *this;
 	}
 
 	Client::~Client()

--- a/src/http/Client.cpp
+++ b/src/http/Client.cpp
@@ -6,7 +6,7 @@
 //   By: maurodri <maurodri@student.42sp...>        +#+  +:+       +#+        //
 //                                                +#+#+#+#+#+   +#+           //
 //   Created: 2025/08/27 17:43:15 by maurodri          #+#    #+#             //
-//   Updated: 2025/08/28 20:25:56 by maurodri         ###   ########.fr       //
+//   Updated: 2025/08/28 20:29:39 by maurodri         ###   ########.fr       //
 //                                                                            //
 // ************************************************************************** //
 
@@ -51,7 +51,7 @@ namespace http {
 
 	Request Client::readHttpRequest()
 	{
-		this->request.readFromTcpClient(*this);
+		this->request.readHttpRequest(*this);
 		return this->request;
 	}
 

--- a/src/http/Client.cpp
+++ b/src/http/Client.cpp
@@ -1,0 +1,64 @@
+// ************************************************************************** //
+//                                                                            //
+//                                                        :::      ::::::::   //
+//   Client.cpp                                         :+:      :+:    :+:   //
+//                                                    +:+ +:+         +:+     //
+//   By: maurodri <maurodri@student.42sp...>        +#+  +:+       +#+        //
+//                                                +#+#+#+#+#+   +#+           //
+//   Created: 2025/08/27 17:43:15 by maurodri          #+#    #+#             //
+//   Updated: 2025/08/27 21:34:52 by maurodri         ###   ########.fr       //
+//                                                                            //
+// ************************************************************************** //
+
+#include "Client.hpp"
+
+namespace http {
+
+	Client::Client(): conn::TcpClient(0)
+	{
+	}
+
+	Client::Client(int clientFd): conn::TcpClient(clientFd)
+	{
+	}
+
+	Client::Client(const Client &other): conn::TcpClient(other)
+	{
+		//TODO
+	}
+
+	Client &Client::operator=(const Client &other)
+	{
+		if (this == &other)
+			return *this;
+		//TODO
+
+		return *this;
+	}
+
+	Client::~Client()
+	{
+		//TODO
+	}
+
+	Request Client::readHttpRequest()
+	{
+		this->request.readFromTcpClient(*this);
+		return this->request;
+	}
+
+	std::string Client::responseAsString() const
+	{
+		if (this->request.state() == http::Request::READ_BAD_REQUEST)
+			return "HTTP/1.1 400 Bad Request\r\n\r\n";
+		else if (this->request.state() == http::Request::READ_ERROR)
+			return "HTTP/1.1 500 Internal Server Error\r\n\r\n";
+		return "HTTP/1.1 404 Not Found\r\n\r\n";
+    }
+
+    void Client::clear()
+	{
+		this->request.clear();
+		// this->response.clear();
+    }
+}

--- a/src/http/Client.hpp
+++ b/src/http/Client.hpp
@@ -6,7 +6,7 @@
 //   By: maurodri <maurodri@student.42sp...>        +#+  +:+       +#+        //
 //                                                +#+#+#+#+#+   +#+           //
 //   Created: 2025/08/27 17:34:03 by maurodri          #+#    #+#             //
-//   Updated: 2025/08/27 19:27:11 by maurodri         ###   ########.fr       //
+//   Updated: 2025/08/28 20:20:17 by maurodri         ###   ########.fr       //
 //                                                                            //
 // ************************************************************************** //
 
@@ -33,6 +33,7 @@ namespace http
 		Client(const Client &other);
 		Client(int clientFd);
 		virtual Client &operator=(const Client &other);
+		virtual Client &operator=(const conn::TcpClient &other);
 		virtual ~Client();
 		Request readHttpRequest();
 		std::string responseAsString() const;

--- a/src/http/Client.hpp
+++ b/src/http/Client.hpp
@@ -1,0 +1,44 @@
+// ************************************************************************** //
+//                                                                            //
+//                                                        :::      ::::::::   //
+//   Client.hpp                                         :+:      :+:    :+:   //
+//                                                    +:+ +:+         +:+     //
+//   By: maurodri <maurodri@student.42sp...>        +#+  +:+       +#+        //
+//                                                +#+#+#+#+#+   +#+           //
+//   Created: 2025/08/27 17:34:03 by maurodri          #+#    #+#             //
+//   Updated: 2025/08/27 19:27:11 by maurodri         ###   ########.fr       //
+//                                                                            //
+// ************************************************************************** //
+
+#ifndef CLIENT_HPP
+# define CLIENT_HPP
+
+# include "TcpClient.hpp"
+# include "Request.hpp"
+
+namespace http
+{
+
+	class Client : public conn::TcpClient
+	{
+
+		Request request;
+		// Response response
+
+		Client();
+
+	public:
+
+
+		Client(const Client &other);
+		Client(int clientFd);
+		virtual Client &operator=(const Client &other);
+		virtual ~Client();
+		Request readHttpRequest();
+		std::string responseAsString() const;
+		std::string responseBadRequest() const;
+		void clear(void);
+	};
+}
+
+#endif

--- a/src/http/Headers.cpp
+++ b/src/http/Headers.cpp
@@ -6,7 +6,7 @@
 /*   By: vcarrara <vcarrara@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/27 13:47:25 by vcarrara          #+#    #+#             */
-/*   Updated: 2025/08/27 14:24:46 by vcarrara         ###   ########.fr       */
+//   Updated: 2025/08/27 18:53:47 by maurodri         ###   ########.fr       //
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -50,5 +50,9 @@ namespace http {
 		if (it != _headers.end())
 			return it->second;
 		return "";
+	}
+
+	void Headers::clear(void) {
+		this->_headers.clear();
 	}
 }

--- a/src/http/Headers.hpp
+++ b/src/http/Headers.hpp
@@ -6,7 +6,7 @@
 /*   By: vcarrara <vcarrara@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/27 13:47:20 by vcarrara          #+#    #+#             */
-/*   Updated: 2025/08/27 14:09:22 by vcarrara         ###   ########.fr       */
+//   Updated: 2025/08/27 18:53:55 by maurodri         ###   ########.fr       //
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,6 +27,7 @@ namespace http {
 			bool parseLine(const std::string &line);
 
 			std::string getHeader(const std::string &key) const;
+			void clear(void);
 
 		private:
 			std::map<std::string, std::string> _headers;

--- a/src/http/Request.cpp
+++ b/src/http/Request.cpp
@@ -6,7 +6,7 @@
 /*   By: vcarrara <vcarrara@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/25 10:51:33 by vcarrara          #+#    #+#             */
-//   Updated: 2025/08/28 20:21:38 by maurodri         ###   ########.fr       //
+//   Updated: 2025/08/28 20:29:40 by maurodri         ###   ########.fr       //
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,7 +52,7 @@ namespace http
 		return true;
 	}
 
-	Request::ReadState Request::readFromTcpClient(conn::TcpClient &client) {
+	Request::ReadState Request::readHttpRequest(conn::TcpClient &client) {
 		std::pair<BufferedReader::ReadState, char*> result;
 
 		switch (_state) {

--- a/src/http/Request.cpp
+++ b/src/http/Request.cpp
@@ -6,7 +6,7 @@
 /*   By: vcarrara <vcarrara@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/25 10:51:33 by vcarrara          #+#    #+#             */
-//   Updated: 2025/08/28 20:29:40 by maurodri         ###   ########.fr       //
+//   Updated: 2025/08/28 21:03:38 by maurodri         ###   ########.fr       //
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,115 +52,137 @@ namespace http
 		return true;
 	}
 
-	Request::ReadState Request::readHttpRequest(conn::TcpClient &client) {
+	Request::ReadState Request::readRequestLine(conn::TcpClient &client)
+	{
+		std::pair<BufferedReader::ReadState, char*> result;
+		result = client.readlineCrlf();
+
+		switch(result.first) {
+		case BufferedReader::READING: {
+			return _state;
+		}
+		case BufferedReader::ERROR: {
+			_state = READ_ERROR;
+			return _state;
+		}
+		case BufferedReader::NO_CONTENT: {
+			delete[] result.second;
+			_state = READ_EOF;
+			return _state;
+		}
+		case BufferedReader::DONE: {
+			if (!parseRequestLine(std::string(result.second)))
+			{
+				_state = READ_BAD_REQUEST;
+				delete[] result.second;
+				return _state;
+			}
+			delete[] result.second;
+			_state = READING_HEADERS;
+			return _state;
+		}
+		default: return _state;
+		}
+	}
+
+	Request::ReadState Request::readHeaderLine(conn::TcpClient &client)
+	{
 		std::pair<BufferedReader::ReadState, char*> result;
 
+		result = client.readlineCrlf();
+
+		switch(result.first) {
+		case BufferedReader::READING:
+			return _state;
+		case BufferedReader::ERROR: {
+			_state = READ_ERROR;
+			return _state;
+		}
+		case BufferedReader::NO_CONTENT: {
+			delete[] result.second;
+			_state = READ_EOF;
+			return _state;
+		}
+		case BufferedReader::DONE:
+		{
+			std::string line(result.second);
+			delete[] result.second;
+
+			if (line.empty()) { // End of Headers
+				std::string contentLength = _headers.getHeader("Content-Length");
+				if (!contentLength.empty())
+					_state = READING_BODY; // Body to read
+				else
+					_state = READ_COMPLETE; // No body to read
+			}
+			else if (!_headers.parseLine(line)) { // unexpected format
+				_state = READ_BAD_REQUEST;
+			}
+			return _state;
+		}
+		default:
+			return _state;
+		}
+	}
+
+	Request::ReadState Request::readBody(conn::TcpClient &client)
+	{
+		std::pair<BufferedReader::ReadState, char*> result;
+
+		std::string contentLength = _headers.getHeader("Content-Length");
+		size_t expectedLength = 0;
+		if (!contentLength.empty()) {
+			expectedLength = std::strtoul(contentLength.c_str(), NULL, 10);
+		}
+
+		result = client.read(expectedLength - _body.size());
+		switch(result.first) {
+		case BufferedReader::READING:
+			return _state;
+		case BufferedReader::ERROR: {
+			_state = READ_ERROR;
+			return _state;
+		}
+		case BufferedReader::NO_CONTENT: {
+			_state = READ_EOF;
+			return _state;
+		}
+		case BufferedReader::DONE: {
+			if (!_body.parse(result.second, expectedLength)) {
+				delete[] result.second;
+				return _state;
+			}
+			delete[] result.second;
+
+			// Check if the body has been fully read
+			if (_body.size() >= expectedLength) {
+				_state = READ_COMPLETE;
+			}
+			return _state;
+		}
+		default:
+			return _state;
+		}
+	}
+	
+
+	Request::ReadState Request::readHttpRequest(conn::TcpClient &client) {
+
 		switch (_state) {
-		case READING_REQUEST_LINE: {
-			result = client.readlineCrlf();
-
-			if (result.first == BufferedReader::READING)
-				return _state;
-			else if (result.first == BufferedReader::ERROR)
-			{
-				_state = READ_ERROR;
-				return _state;
-			}
-			else if (result.first == BufferedReader::NO_CONTENT)
-			{
-				delete[] result.second;
-				_state = READ_EOF;
-				return _state;
-			}
-			else if (result.first == BufferedReader::DONE)
-			{
-				if (!parseRequestLine(std::string(result.second)))
-				{
-					_state = READ_BAD_REQUEST;
-					delete[] result.second;
-					return _state;
-				}
-				delete[] result.second;
-				_state = READING_HEADERS;
-				return _state;
-			}
-			return _state;
-		}
-
-		case READING_HEADERS: {
-			result = client.readlineCrlf();
-
-			if (result.first == BufferedReader::READING)
-				return _state;
-			else if (result.first == BufferedReader::ERROR) {
-				_state = READ_ERROR;
-				return _state;
-			}
-			else if (result.first == BufferedReader::NO_CONTENT)
-			{
-				delete[] result.second;
-				_state = READ_EOF;
-				return _state;
-			}
-			else if (result.first == BufferedReader::DONE)
-			{
-				std::string line(result.second);
-				delete[] result.second;
-
-				if (line.empty()) { // End of Headers
-					std::string contentLength = _headers.getHeader("Content-Length");
-					if (!contentLength.empty())
-						_state = READING_BODY; // Body to read
-					else
-						_state = READ_COMPLETE; // No body to read
-				}
-				else if (!_headers.parseLine(line)) { // unexpected format
-					_state = READ_BAD_REQUEST;
-				}
-				return _state;
-			}
-			return _state;
-		}
-
-		case READING_BODY: {
-			std::string contentLength = _headers.getHeader("Content-Length");
-			size_t expectedLength = 0;
-			if (!contentLength.empty()) {
-				expectedLength = std::strtoul(contentLength.c_str(), NULL, 10);
-			}
-
-			result = client.read(expectedLength - _body.size());
-			if (BufferedReader::READING)
-				return _state;
-			else if (result.first == BufferedReader::ERROR) {
-				_state = READ_ERROR;
-				return _state;
-			}
-			else if (result.first == BufferedReader::NO_CONTENT) {
-				_state = READ_EOF;
-				return _state;
-			} else if (result.first == BufferedReader::DONE) {
-				if (!_body.parse(result.second, expectedLength)) {
-					delete[] result.second;
-					return _state;
-				}
-				delete[] result.second;
-
-				// Check if the body has been fully read
-				if (_body.size() >= expectedLength) {
-					_state = READ_COMPLETE;
-				}
-				return _state;
-			}
-			return _state;
-		}
+		case READING_REQUEST_LINE:
+			return readRequestLine(client);
+		case READING_HEADERS: 
+			return readHeaderLine(client);
+		case READING_BODY:
+			return readBody(client);
 		case READ_BAD_REQUEST:
 		case READ_EOF:
 		case READ_ERROR:
 		case READ_COMPLETE:
-				return _state;
+			return _state;
+		default:
+			return _state;
 		}
-		return _state;
 	}
 
 	std::string Request::getMethod() const { return _method; }

--- a/src/http/Request.cpp
+++ b/src/http/Request.cpp
@@ -6,7 +6,7 @@
 /*   By: vcarrara <vcarrara@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/25 10:51:33 by vcarrara          #+#    #+#             */
-//   Updated: 2025/08/27 19:25:32 by maurodri         ###   ########.fr       //
+//   Updated: 2025/08/28 20:21:38 by maurodri         ###   ########.fr       //
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -84,6 +84,7 @@ namespace http
 				_state = READING_HEADERS;
 				return _state;
 			}
+			return _state;
 		}
 
 		case READING_HEADERS: {
@@ -118,6 +119,7 @@ namespace http
 				}
 				return _state;
 			}
+			return _state;
 		}
 
 		case READING_BODY: {
@@ -150,6 +152,7 @@ namespace http
 				}
 				return _state;
 			}
+			return _state;
 		}
 		case READ_BAD_REQUEST:
 		case READ_EOF:
@@ -157,6 +160,7 @@ namespace http
 		case READ_COMPLETE:
 				return _state;
 		}
+		return _state;
 	}
 
 	std::string Request::getMethod() const { return _method; }

--- a/src/http/Request.hpp
+++ b/src/http/Request.hpp
@@ -6,7 +6,7 @@
 /*   By: vcarrara <vcarrara@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/25 10:41:51 by vcarrara          #+#    #+#             */
-//   Updated: 2025/08/27 19:25:49 by maurodri         ###   ########.fr       //
+//   Updated: 2025/08/28 20:29:21 by maurodri         ###   ########.fr       //
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,7 +39,7 @@ namespace http
 		virtual Request &operator=(const Request &other);
 		virtual ~Request(void);
 
-		ReadState readFromTcpClient(conn::TcpClient &client);
+		ReadState readHttpRequest(conn::TcpClient &client);
 		ReadState state(void) const { return _state; }
 		void clear(void);
 

--- a/src/http/Request.hpp
+++ b/src/http/Request.hpp
@@ -6,7 +6,7 @@
 /*   By: vcarrara <vcarrara@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/25 10:41:51 by vcarrara          #+#    #+#             */
-/*   Updated: 2025/08/27 13:38:18 by vcarrara         ###   ########.fr       */
+//   Updated: 2025/08/27 19:25:49 by maurodri         ###   ########.fr       //
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,10 +16,7 @@
 #include <string>
 #include "Headers.hpp"
 #include "Body.hpp"
-
-namespace conn {
-	class TcpClient;
-}
+#include "TcpClient.hpp"
 
 namespace http
 {
@@ -32,7 +29,9 @@ namespace http
 			READING_HEADERS,
 			READING_BODY,
 			READ_ERROR,
-			READ_COMPLETE
+			READ_BAD_REQUEST,
+			READ_COMPLETE,
+			READ_EOF
 		};
 
 		Request(void);
@@ -42,6 +41,7 @@ namespace http
 
 		ReadState readFromTcpClient(conn::TcpClient &client);
 		ReadState state(void) const { return _state; }
+		void clear(void);
 
 		std::string getMethod(void) const;
 		std::string getPath(void) const;

--- a/src/http/Request.hpp
+++ b/src/http/Request.hpp
@@ -6,7 +6,7 @@
 /*   By: vcarrara <vcarrara@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/25 10:41:51 by vcarrara          #+#    #+#             */
-//   Updated: 2025/08/28 20:29:21 by maurodri         ###   ########.fr       //
+//   Updated: 2025/08/28 20:55:06 by maurodri         ###   ########.fr       //
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -60,6 +60,9 @@ namespace http
 		ReadState _state;
 
 		bool parseRequestLine(const std::string &line);
+		ReadState readRequestLine(conn::TcpClient &client);
+		ReadState readHeaderLine(conn::TcpClient &client);
+		ReadState readBody(conn::TcpClient &client);
 	};
 }
 


### PR DESCRIPTION
makes possible to read a http request from a tcp connection

creates a http::Client class that integrates the conn::TcpClient with http::Request and http:Response

known bugs:
  - request from browser is not working
    - if a single read has many \r\n and fd content is exausted then epoll does not trigger a new event for read and the function that reads lines is not invocked anymore