### PR TITLE
feat: add TRACE support and proper Content-Length in responseAsString

### DIFF
--- a/src/http/Client.cpp
+++ b/src/http/Client.cpp
@@ -6,11 +6,12 @@
 /*   By: vcarrara <vcarrara@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/27 17:43:15 by maurodri          #+#    #+#             */
-/*   Updated: 2025/09/02 14:32:38 by vcarrara         ###   ########.fr       */
+/*   Updated: 2025/09/02 16:28:24 by vcarrara         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "Client.hpp"
+#include <sstream>
 
 namespace http {
 
@@ -57,21 +58,28 @@ namespace http {
 
 	std::string Client::responseAsString() const
 	{
-		http::Response response;
+		Response r = response;
+
 		if (this->request.state() == http::Request::READ_BAD_REQUEST) {
-			response.setStatusCode(400);
-			response.setStatusInfo("Bad Request");
+			r.setStatusCode(400);
+			r.setStatusInfo("Bad Request");
 		} else if (this->request.state() == http::Request::READ_ERROR) {
-			response.setStatusCode(500);
-			response.setStatusInfo("Internal Server Error");
+			r.setStatusCode(500);
+			r.setStatusInfo("Internal Server Error");
+		} else if (this->request.getMethod() == "TRACE") {
+			r.setStatusCode(200);
+			r.setStatusInfo("OK");
+			r.setBody(this->request.getBody());
 		} else {
-			response.setStatusCode(404);
-			response.setStatusInfo("Not found");
+			r.setStatusCode(404);
+			r.setStatusInfo("Not Found");
 		}
 
-		response.addHeader("Content-Length", "0");
+		std::ostringstream length;
+		length << r.getBody().size();
+		r.addHeader("Content-Length", length.str());
 
-		return response.toString();
+		return r.toString();
 	}
 
 	void Client::clear()

--- a/src/http/Response.cpp
+++ b/src/http/Response.cpp
@@ -6,7 +6,7 @@
 /*   By: vcarrara <vcarrara@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/09/02 13:22:28 by vcarrara          #+#    #+#             */
-/*   Updated: 2025/09/02 14:32:23 by vcarrara         ###   ########.fr       */
+/*   Updated: 2025/09/02 15:27:26 by vcarrara         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -51,8 +51,14 @@ namespace http {
 		_headers.parseLine(key + ": " + value);
 	}
 
-	void Response::setBody(const Body &body) {
-		_body = body;
+	void Response::setBody(const std::string &content) {
+		Body b;
+		b.parse(content.c_str(), content.size());
+		_body = b;
+	}
+
+	Body Response::getBody(void) const {
+		return _body;
 	}
 
 	std::string Response::toString(void) const {

--- a/src/http/Response.hpp
+++ b/src/http/Response.hpp
@@ -6,7 +6,7 @@
 /*   By: vcarrara <vcarrara@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/09/02 13:22:22 by vcarrara          #+#    #+#             */
-/*   Updated: 2025/09/02 14:32:00 by vcarrara         ###   ########.fr       */
+/*   Updated: 2025/09/02 15:27:52 by vcarrara         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,8 +30,10 @@ namespace http {
 			void setStatusCode(int code);
 			void setStatusInfo(const std::string &info);
 
+			void setBody(const std::string &body);
+			Body getBody(void) const;
+
 			void addHeader(const std::string &key, const std::string &value);
-			void setBody(const Body &body);
 			void clear(void);
 
 			std::string toString(void) const;


### PR DESCRIPTION
## This PR improves HTTP response handling in Client::responseAsString() by:

- Adding support for the TRACE method, echoing the request body in the response.

- Ensuring the Content-Length header is always calculated based on the body size.

- Returning the correct Response object instead of the stale member instance.

- Preserving existing error handling for 400 (Bad Request), 500 (Internal Server Error), and 404 (Not Found).