### PR TITLE
Reformat epoll to poll event loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,14 +208,14 @@
     - [X] Reformat EventLoop
       - change IO Multiplexing from epoll to poll
         - epoll does not work with regular files
-	- subject states that
-	  - all reads and writes except configuration file should happen through poll (multiplexer)
-	    - this includes reading regular files while responding to requests
-	    - poll states that it does not make sense to monitor regular files fds
-	      - select and poll always consider regular files ready to read and write
-	        - this is related to in-kernel buffering of io to disk
-	      - but it is still possible to monitor regular files with poll
-	     - epoll does not allow monitoring regular files
+    - subject states that
+      - all reads and writes except configuration file should happen through poll (multiplexer)
+        - this includes reading regular files while responding to requests
+        - poll states that it does not make sense to monitor regular files fds
+          - select and poll always consider regular files ready to read and write
+            - this is related to in-kernel buffering of io to disk
+          - but it is still possible to monitor regular files with poll
+         - epoll does not allow monitoring regular files
     - handle file reading on EventLoop
     - handle file writing on EventLoop
     - handle cgi ipc on EventLoop
@@ -232,9 +232,9 @@
       - each socket is bidirectional
       - child-cgi
         - redirect child stdin and stdout to one side of socketpair
-	- close other side of socketpair
+        - close other side of socketpair
       - server
         - subscribe read/write to cgi on EventLoop
-	- write body
-	- read cgi-response
-	- write full response
+        - write body
+        - read cgi-response
+        - write full response

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@
     - [X] use epoll or something alike
     - handle todos left on EventLoop
     - [X] fix issues of buffered reader: a read may contain several \r\n in a single read
-    - [ ] Reformat EventLoop
+    - [X] Reformat EventLoop
       - change IO Multiplexing from epoll to poll
         - epoll does not work with regular files
 	- subject states that

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@
     - [X] use epoll or something alike
     - handle todos left on EventLoop
     - [X] fix issues of buffered reader: a read may contain several \r\n in a single read
-    - Reformat EventLoop
+    - [ ] Reformat EventLoop
       - change IO Multiplexing from epoll to poll
         - epoll does not work with regular files
 	- subject states that

--- a/src/conn/EventLoop.cpp
+++ b/src/conn/EventLoop.cpp
@@ -6,7 +6,7 @@
 //   By: maurodri <maurodri@student.42sp...>        +#+  +:+       +#+        //
 //                                                +#+#+#+#+#+   +#+           //
 //   Created: 2025/08/26 17:06:06 by maurodri          #+#    #+#             //
-//   Updated: 2025/09/09 22:02:11 by maurodri         ###   ########.fr       //
+//   Updated: 2025/09/09 22:11:57 by maurodri         ###   ########.fr       //
 //                                                                            //
 // ************************************************************************** //
 
@@ -75,7 +75,7 @@ namespace conn
 	void EventLoop::unsubscribeFd(EventList::iterator &eventIt)
 	{
 		close(eventIt->fd);
-		eventIt = this->events.erase(eventIt);
+		eventIt = this->events.erase(eventIt) - 1;
 	}
 
 	void EventLoop::unsubscribeHttpClient(

--- a/src/conn/EventLoop.cpp
+++ b/src/conn/EventLoop.cpp
@@ -6,7 +6,7 @@
 //   By: maurodri <maurodri@student.42sp...>        +#+  +:+       +#+        //
 //                                                +#+#+#+#+#+   +#+           //
 //   Created: 2025/08/26 17:06:06 by maurodri          #+#    #+#             //
-//   Updated: 2025/09/09 21:50:48 by maurodri         ###   ########.fr       //
+//   Updated: 2025/09/09 22:02:11 by maurodri         ###   ########.fr       //
 //                                                                            //
 // ************************************************************************** //
 
@@ -14,6 +14,7 @@
 #include <stdexcept>
 #include <unistd.h>
 #include <iostream>
+#include <cstring>
 
 namespace conn
 {
@@ -73,8 +74,8 @@ namespace conn
 
 	void EventLoop::unsubscribeFd(EventList::iterator &eventIt)
 	{
-		eventIt = this->events.erase(eventIt);
 		close(eventIt->fd);
+		eventIt = this->events.erase(eventIt);
 	}
 
 	void EventLoop::unsubscribeHttpClient(
@@ -187,8 +188,8 @@ namespace conn
 		while (true)
 		{
 			// waiting for ready event from epoll
-			int numReadyEvents =
-				poll(this->events.data(), events.size(), -1); // -1 without timeout
+			 // -1 without timeout
+			int numReadyEvents = poll(this->events.data(), events.size(), -1);
 			if (numReadyEvents < 0)
 			{
 				std::cout << "poll error: " << strerror(errno) << std::endl;
@@ -243,7 +244,6 @@ namespace conn
 					}
 				}
 			}
-
 		}
 	}
 }

--- a/src/conn/EventLoop.cpp
+++ b/src/conn/EventLoop.cpp
@@ -6,7 +6,7 @@
 //   By: maurodri <maurodri@student.42sp...>        +#+  +:+       +#+        //
 //                                                +#+#+#+#+#+   +#+           //
 //   Created: 2025/08/26 17:06:06 by maurodri          #+#    #+#             //
-//   Updated: 2025/09/04 18:19:25 by maurodri         ###   ########.fr       //
+//   Updated: 2025/09/09 18:02:50 by maurodri         ###   ########.fr       //
 //                                                                            //
 // ************************************************************************** //
 
@@ -18,86 +18,79 @@
 namespace conn
 {
 
-	EventLoop::EventLoop(): epollFd(epoll_create1(0)) // 0 == no flags
+	EventLoop::EventLoop()
 	{
 	}
 
-	EventLoop::EventLoop(const EventLoop &other) : epollFd(other.epollFd)
+	EventLoop::EventLoop(const EventLoop &other)
 	{
-
+		(void) other;
 	}
 
 	EventLoop &EventLoop::operator=(const EventLoop &other)
 	{
 		if (this == &other)
 			return *this;
-		this->epollFd = other.epollFd;
 		return *this;
 	}
 
 	EventLoop::~EventLoop()
 	{
-		close(this->epollFd);
 	}
 
-	bool EventLoop::isOk() const
-	{
-		return this->epollFd >= 0;
-	}
 
 	bool EventLoop::subscribeTcpServer(TcpServer *tcpServer)
 	{
-		if (!this->isOk())
-		{
-			return false;
-		}
+		struct pollfd event;
 
-		struct epoll_event event;
+		event.events = POLLIN; // subscribe for reads only
+		event.fd = tcpServer->getServerFd();
 
-		event.events = EPOLLIN; // subscribe for reads only, level triggered
-		event.data.fd = tcpServer->getServerFd();
-
-		if (epoll_ctl(epollFd, EPOLL_CTL_ADD, event.data.fd, &event))
-		{
-			return false;
-		}
+		this->events.push_back(event);
 		std::pair<MapServerIterator, bool> insertResult =
-			servers.insert(std::make_pair(event.data.fd, tcpServer));
+			servers.insert(std::make_pair(event.fd, tcpServer));
 		return insertResult.second;
 	}
 
 	bool EventLoop::subscribeHttpClient(int fd)
 	{
-		if (!this->isOk())
-		{
-			return false;
-		}
 
-		struct epoll_event event;
+		struct pollfd event;
 
-		event.events = EPOLLIN|EPOLLOUT; // subscribe for reads and writes, level triggered
-		event.data.fd = fd;
-
-		if (epoll_ctl(epollFd, EPOLL_CTL_ADD, event.data.fd, &event))
-		{
-			return false;
-		}
+		event.events = POLLIN|POLLOUT; // subscribe for reads and writes, level triggered
+		event.fd = fd;
 
 		http::Client *httpClient = new http::Client(fd);
 		if (httpClient != 0)
 		{
+			this->events.push_back(event);
 			std::pair<MapClientIterator, bool> insertResult =
-				clients.insert(std::make_pair(event.data.fd, httpClient));
+				clients.insert(std::make_pair(event.fd, httpClient));
 			return insertResult.second;
 		}
 		return false;
 	}
 
-	bool EventLoop::unsubscribeHttpClient(http::Client *client , struct epoll_event *clientEvent)
+	bool EventLoop::unsubscribeFd(int fd)
 	{
-		int clientFd = clientEvent->data.fd;
-		if (epoll_ctl(this->epollFd, EPOLL_CTL_DEL, clientFd, clientEvent) != 0)
+		for (std::vector<struct pollfd>::iterator monitoredIt = this->events.begin();
+			 monitoredIt != this->events.end();
+			 ++monitoredIt)
+		{
+			if (monitoredIt->fd == fd)
+			{
+				this->events.erase(monitoredIt);
+				return true;
+			}
+		}
+		return false;
+	}
+
+	bool EventLoop::unsubscribeHttpClient(int clientFd)
+	{
+		if (!this->unsubscribeFd(clientFd))
 			return false;
+		http::Client *client = this->clients.at(clientFd);
 		if (this->clients.erase(clientFd) != 1)
 			return false;
 		delete client;
@@ -123,7 +116,7 @@ namespace conn
 		}
 	}
 
-	void EventLoop::handleClientRequest(http::Client *client, struct epoll_event *clientEvent)
+	void EventLoop::handleClientRequest(http::Client *client)
 	{
 		http::Request maybeCompleteRequest = client->readHttpRequest();
 		if (maybeCompleteRequest.state() <= http::Request::READING_BODY)
@@ -160,7 +153,7 @@ namespace conn
 			// has finished reading has message but client has closed
 			// TODO confirm that client is always closed on this case
 			std::cout << "eof reading: " << std::endl;
-			unsubscribeHttpClient(client, clientEvent);
+			unsubscribeHttpClient(client->getFd());
 		}
 		else if (maybeCompleteRequest.state() == http::Request::READ_ERROR)
 		{
@@ -168,7 +161,7 @@ namespace conn
 			//unsubscribe
 			std::cout << "error reading: "
 					  << std::endl;
-			unsubscribeHttpClient(client, clientEvent);
+			unsubscribeHttpClient(client->getFd());
 			throw std::domain_error("TODO read ERROR");
 		}
 	}
@@ -194,46 +187,51 @@ namespace conn
 
 	bool EventLoop::loop()
 	{
-		if (!this->isOk())
-		{
-			return false;
-		}
-
-		struct epoll_event events[MAX_EVENTS];
-
 		while (true)
 		{
 			// waiting for ready event from epoll
 			int numReadyEvents =
-				epoll_wait(this->epollFd, events, MAX_EVENTS, -1); // -1 without timeout
+				poll(this->events.data(), events.size(), -1); // -1 without timeout
 
-			// iterating through ready events
-			for(int i = 0; i < numReadyEvents; i++) {
-				// checking which fd to know what to do
-				MapServerIterator serverIt = this->servers.find(events[i].data.fd);
-				if (serverIt != this->servers.end())
-				{
-					TcpServer *server = serverIt->second;
-					this->connectServerToClient(server);
-				}
-				MapClientIterator clientIt = this->clients.find(events[i].data.fd);
-				if (clientIt != this->clients.end())
-				{
-					http::Client *client = clientIt->second;
-					if (events[i].events & EPOLLIN) // fd has content to read
+			for (std::vector<struct pollfd>::iterator monitoredIt = this->events.begin();
+				 monitoredIt != this->events.end() && numReadyEvents > 0;
+				 ++monitoredIt)
+			{
+				if (monitoredIt->revents & POLLIN)
+				{ // fd is available for read
+
+					MapServerIterator serverIt = this->servers.find(monitoredIt->fd);
+					if (serverIt != this->servers.end())
 					{
-						this->handleClientRequest(client, events + i);
+						TcpServer *server = serverIt->second;
+						this->connectServerToClient(server);
 					}
-					else if (events[i].events & EPOLLOUT) // fd is available to write
+					MapClientIterator clientIt = this->clients.find(monitoredIt->fd);
+					if (clientIt != this->clients.end())
 					{
+						http::Client *client = clientIt->second;
+						this->handleClientRequest(client);
+					}
+					--numReadyEvents;
+
+				} else if (monitoredIt->revents & POLLOUT)
+				{ // fd is avalilable for write
+					MapClientIterator clientIt = this->clients.find(monitoredIt->fd);
+					if (clientIt != this->clients.end())
+					{
+						http::Client *client = clientIt->second;
 						this->handleClientWriteResponse(client);
 					}
-					else
+					--numReadyEvents;
+
+				} else if (monitoredIt->revents & (POLLHUP | POLLERR))
+				{ // close
+					MapClientIterator clientIt = this->clients.find(monitoredIt->fd);
+					if (clientIt != this->clients.end())
 					{
-						throw std::domain_error("TODO else error");
-						client->clear();
+						this->unsubscribeHttpClient(monitoredIt->fd);
 					}
-					continue;
+					--numReadyEvents;
 				}
 			}
 

--- a/src/conn/EventLoop.hpp
+++ b/src/conn/EventLoop.hpp
@@ -6,7 +6,7 @@
 //   By: maurodri <maurodri@student.42sp...>        +#+  +:+       +#+        //
 //                                                +#+#+#+#+#+   +#+           //
 //   Created: 2025/08/26 16:57:28 by maurodri          #+#    #+#             //
-//   Updated: 2025/09/09 20:59:34 by maurodri         ###   ########.fr       //
+//   Updated: 2025/09/09 21:39:06 by maurodri         ###   ########.fr       //
 //                                                                            //
 // ************************************************************************** //
 
@@ -24,18 +24,23 @@
 
 namespace conn
 {
+	typedef std::map<int, TcpServer*>::iterator MapServerIterator;
+	typedef std::map<int, http::Client*>::iterator MapClientIterator;
+	typedef std::vector<struct pollfd> EventList;
 
 	class EventLoop
 	{
 		std::map<int, TcpServer*> servers;
 		std::map<int, http::Client*> clients;
-		std::vector<struct pollfd> events;
+		EventList events;
 		http::Dispatcher dispatcher;
 
 		void connectServerToClient(TcpServer *server);
-		void handleClientRequest(http::Client *client);
-		void handleClientWriteResponse(http::Client *client);
-		bool unsubscribeFd(int fd);
+		void handleClientRequest(
+			http::Client *client, EventList::iterator &eventIt);
+		void handleClientWriteResponse(
+			http::Client *client, EventList::iterator &eventIt);
+	    void unsubscribeFd(EventList::iterator &eventIt);
 	public:
 
 		EventLoop();
@@ -47,13 +52,10 @@ namespace conn
 		bool subscribeHttpClient(int fd);
 		bool loop(void);
 
-		bool unsubscribeHttpClient(int clientFd);
+		void unsubscribeHttpClient(EventList::iterator &eventIt);
 
 	};
 
-	typedef std::map<int, TcpServer*>::iterator MapServerIterator;
-	typedef std::map<int, http::Client*>::iterator MapClientIterator;
-	typedef std::vector<struct pollfd> EventList;
 }
 
 #endif

--- a/src/conn/EventLoop.hpp
+++ b/src/conn/EventLoop.hpp
@@ -6,7 +6,7 @@
 //   By: maurodri <maurodri@student.42sp...>        +#+  +:+       +#+        //
 //                                                +#+#+#+#+#+   +#+           //
 //   Created: 2025/08/26 16:57:28 by maurodri          #+#    #+#             //
-//   Updated: 2025/09/04 18:19:19 by maurodri         ###   ########.fr       //
+//   Updated: 2025/09/09 18:01:13 by maurodri         ###   ########.fr       //
 //                                                                            //
 // ************************************************************************** //
 
@@ -18,7 +18,7 @@
 #include "TcpClient.hpp"
 #include "Dispatcher.hpp"
 #include "Client.hpp"
-#include <sys/epoll.h>
+#include <poll.h>
 
 # define MAX_EVENTS 6
 
@@ -27,14 +27,15 @@ namespace conn
 
 	class EventLoop
 	{
-		int epollFd;
 		std::map<int, TcpServer*> servers;
 		std::map<int, http::Client*> clients;
+		std::vector<struct pollfd> events;
 		http::Dispatcher dispatcher;
 
 		void connectServerToClient(TcpServer *server);
-		void handleClientRequest(http::Client *client, struct epoll_event *clientEvent);
+		void handleClientRequest(http::Client *client);
 		void handleClientWriteResponse(http::Client *client);
+		bool unsubscribeFd(int fd);
 	public:
 
 		EventLoop();
@@ -45,8 +46,8 @@ namespace conn
 		bool subscribeTcpServer(TcpServer *tcpServer);
 		bool subscribeHttpClient(int fd);
 		bool loop(void);
-		bool isOk() const;
-		bool unsubscribeHttpClient(http::Client *client , struct epoll_event *clientEvent);
+
+		bool unsubscribeHttpClient(int clientFd);
 
 	};
 

--- a/src/conn/EventLoop.hpp
+++ b/src/conn/EventLoop.hpp
@@ -6,7 +6,7 @@
 //   By: maurodri <maurodri@student.42sp...>        +#+  +:+       +#+        //
 //                                                +#+#+#+#+#+   +#+           //
 //   Created: 2025/08/26 16:57:28 by maurodri          #+#    #+#             //
-//   Updated: 2025/09/09 18:01:13 by maurodri         ###   ########.fr       //
+//   Updated: 2025/09/09 20:59:34 by maurodri         ###   ########.fr       //
 //                                                                            //
 // ************************************************************************** //
 
@@ -53,6 +53,7 @@ namespace conn
 
 	typedef std::map<int, TcpServer*>::iterator MapServerIterator;
 	typedef std::map<int, http::Client*>::iterator MapClientIterator;
+	typedef std::vector<struct pollfd> EventList;
 }
 
 #endif

--- a/src/conn/TcpClient.cpp
+++ b/src/conn/TcpClient.cpp
@@ -6,7 +6,7 @@
 //   By: maurodri <maurodri@student.42.fr>          +#+  +:+       +#+        //
 //                                                +#+#+#+#+#+   +#+           //
 //   Created: 2025/08/25 21:44:37 by maurodri          #+#    #+#             //
-//   Updated: 2025/08/29 00:16:51 by maurodri         ###   ########.fr       //
+//   Updated: 2025/09/09 17:57:19 by maurodri         ###   ########.fr       //
 //                                                                            //
 // ************************************************************************** //
 
@@ -84,5 +84,10 @@ namespace conn
 	bool TcpClient::hasBufferedContent() const
 	{
 		return this->reader.hasBufferedContent();
+	}
+
+	int TcpClient::getFd() const
+	{
+		return this->clientFd;
 	}
 }

--- a/src/conn/TcpClient.hpp
+++ b/src/conn/TcpClient.hpp
@@ -6,7 +6,7 @@
 //   By: maurodri <maurodri@student.42.fr>          +#+  +:+       +#+        //
 //                                                +#+#+#+#+#+   +#+           //
 //   Created: 2025/08/25 21:44:02 by maurodri          #+#    #+#             //
-//   Updated: 2025/08/29 00:16:28 by maurodri         ###   ########.fr       //
+//   Updated: 2025/09/09 17:57:18 by maurodri         ###   ########.fr       //
 //                                                                            //
 // ************************************************************************** //
 
@@ -39,6 +39,7 @@ namespace conn {
 		std::pair<ReadState, char *> read(size_t length);
 		std::pair<ReadState, char *> readlineCrlf();
 		bool hasBufferedContent() const;
+		int getFd() const;
 	};
 }
 

--- a/src/http/Client.cpp
+++ b/src/http/Client.cpp
@@ -6,7 +6,7 @@
 /*   By: vcarrara <vcarrara@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/27 17:43:15 by maurodri          #+#    #+#             */
-//   Updated: 2025/09/03 19:31:34 by maurodri         ###   ########.fr       //
+//   Updated: 2025/09/09 17:56:25 by maurodri         ###   ########.fr       //
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,14 +34,6 @@ namespace http {
 		//TODO
 
 		return *this;
-	}
-
-	Client &Client::operator=(const conn::TcpClient &other) {
-			if (this == &other) {
-				return *this;
-			}
-			conn::TcpClient::operator=(other);
-			return *this;
 	}
 
 	Client::~Client()

--- a/src/http/Client.hpp
+++ b/src/http/Client.hpp
@@ -6,7 +6,7 @@
 /*   By: vcarrara <vcarrara@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/27 17:34:03 by maurodri          #+#    #+#             */
-//   Updated: 2025/09/03 20:33:00 by maurodri         ###   ########.fr       //
+//   Updated: 2025/09/09 17:49:38 by maurodri         ###   ########.fr       //
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,8 +33,7 @@ namespace http
 
 		Client(const Client &other);
 		Client(int clientFd);
-		virtual Client &operator=(const Client &other);
-		virtual Client &operator=(const conn::TcpClient &other);
+		Client &operator=(const Client &other);
 		virtual ~Client();
 		Request &readHttpRequest();
 		Response &getResponse();

--- a/src/http/Response.cpp
+++ b/src/http/Response.cpp
@@ -6,7 +6,7 @@
 /*   By: vcarrara <vcarrara@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/09/02 13:22:28 by vcarrara          #+#    #+#             */
-//   Updated: 2025/09/04 17:50:26 by maurodri         ###   ########.fr       //
+//   Updated: 2025/09/09 21:47:24 by maurodri         ###   ########.fr       //
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,6 +39,10 @@ namespace http {
 	Response::~Response(void)
 	{
 
+	}
+
+	std::string Response::getHeader(const std::string &key) const {
+		return _headers.getHeader(key);
 	}
 
 	Response &Response::setProtocol(const std::string &protocol) {

--- a/src/http/Response.hpp
+++ b/src/http/Response.hpp
@@ -6,7 +6,7 @@
 /*   By: vcarrara <vcarrara@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/09/02 13:22:22 by vcarrara          #+#    #+#             */
-//   Updated: 2025/09/04 17:07:59 by maurodri         ###   ########.fr       //
+//   Updated: 2025/09/09 21:47:19 by maurodri         ###   ########.fr       //
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,6 +25,8 @@ namespace http {
 			Response(const Response &other);
 			virtual Response &operator=(const Response &other);
 			virtual ~Response(void);
+
+			std::string getHeader(const std::string &key) const;
 
 			Response &setProtocol(const std::string &protocol);
 			Response &setStatusCode(int code);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 //   By: maurodri <maurodri@student.42sp...>        +#+  +:+       +#+        //
 //                                                +#+#+#+#+#+   +#+           //
 //   Created: 2025/08/19 17:11:02 by maurodri          #+#    #+#             //
-//   Updated: 2025/08/26 22:25:30 by maurodri         ###   ########.fr       //
+//   Updated: 2025/09/09 17:24:17 by maurodri         ###   ########.fr       //
 //                                                                            //
 // ************************************************************************** //
 
@@ -18,11 +18,6 @@ int main(void)
 {
 	conn::EventLoop eventLoop;
 
-	if (!eventLoop.isOk())
-	{
-		std::cout << "failed to create epoll" << std::endl;
-		return 11;
-	}
 	conn::TcpServer server;
 	std::pair<int, std::string> maybeServerFd = server.createAndListen(8080);
 	if (maybeServerFd.first < 0)


### PR DESCRIPTION
changes EventLoop to use poll instead of epoll.

epoll does not allow monitoring regular files fd and subject requires all fds interation to happen through multiplexer (select, poll or epoll), with only exception the configuration file that happens outside of request response cycle.
poll states on man that monitoring regular files does not make sense, because they always consider that it is possible to read/write to/from regular files (this is related to in-kernal buffering of disk-io),
but poll does allow monitoring regular files although it states that it does not make sense.

It is possible to argue that subject has a requirement that does not make sense, but to follow subject without arguing on defense we can just use poll instead of epoll, which this pull request implements
