### PR TITLE
Feat/http/dispatcher delete

### DIFF
--- a/src/http/Dispatcher.cpp
+++ b/src/http/Dispatcher.cpp
@@ -6,7 +6,7 @@
 /*   By: vcarrara <vcarrara@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/09/03 17:41:30 by maurodri          #+#    #+#             */
-/*   Updated: 2025/09/15 11:10:55 by vcarrara         ###   ########.fr       */
+/*   Updated: 2025/09/15 11:18:13 by vcarrara         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -79,6 +79,24 @@ namespace http {
 
 			close(fd);
 			response.setCreated();
+			client.setMessageToSend(response.toString());
+			return ;
+		}
+
+		if (method == "DELETE") {
+			const std::string &path = client.getRequest().getPath();
+			std::string docroot = "./www";
+			std::string filePath = docroot + path;
+
+			int result = unlink(filePath.c_str());
+			if (result == 0) {
+				response.clear();
+				response.setStatusCode(204);
+				response.setStatusInfo("No Content");
+			} else {
+				response.setNotFound();
+			}
+
 			client.setMessageToSend(response.toString());
 			return ;
 		}


### PR DESCRIPTION
- Compute filepath: Combine docroot with the requested path.
- Delete file: Use unlink() for a blocking deletion.
- Respond:
-- 204 No Content if deletion succeeds.
-- 404 Not Found if the file doesn't exist or deletion fails.
- Blocking: This implementation blocks until unlink() finishes — no EventLoop integration yet.
- Single server assumption: Works directly with the current client; no multiplexing required.