### PR TITLE
Fix: case sensitive header comparison could fail depending on browser

### DIFF
--- a/src/conn/EventLoop.cpp
+++ b/src/conn/EventLoop.cpp
@@ -6,7 +6,7 @@
 /*   By: vcarrara <vcarrara@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/26 17:06:06 by maurodri          #+#    #+#             */
-/*   Updated: 2025/10/07 00:56:24 by maurodri         ###   ########.fr       */
+//   Updated: 2025/10/07 17:44:43 by maurodri         ###   ########.fr       //
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -343,9 +343,11 @@ namespace conn
 			case http::Request::READ_COMPLETE: {
 				// has finished reading has message and client still alive
 				std::cout << "done reading: "
-					  << req.getMethod() << " "
-					  << req.getPath() << " "
-					  << req.getProtocol() << std::endl;
+					  // << req.getMethod() << " "
+					  // << req.getPath() << " "
+					  // << req.getProtocol()
+						  << req.toString()
+						  << std::endl;
 
 				dispatcher.dispatch(*client, *this);
 

--- a/src/http/Headers.cpp
+++ b/src/http/Headers.cpp
@@ -6,7 +6,7 @@
 /*   By: vcarrara <vcarrara@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/27 13:47:25 by vcarrara          #+#    #+#             */
-//   Updated: 2025/10/02 15:32:21 by maurodri         ###   ########.fr       //
+//   Updated: 2025/10/07 19:23:37 by maurodri         ###   ########.fr       //
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,6 +15,22 @@
 #include <sstream>
 
 namespace http {
+	bool Headers::CaseInsensitive::operator()(const std::string &s1, const std::string &s2) const
+	{
+		const char *str1 = s1.c_str();
+		const char *str2 = s2.c_str();
+		int i = 0;
+		char ch1 = ::tolower(str1[i]);
+		char ch2 = ::tolower(str2[i]);
+		while (str1[i] && str2[i] && ch1 == ch2)
+		{
+			++i;
+			ch1 = ::tolower(str1[i]);
+			ch2 = ::tolower(str2[i]);
+		}
+		return ch1 < ch2;
+	}
+
 	Headers::Headers(void) {}
 	Headers::Headers(const Headers &other) {
 		this->_headers = other._headers;
@@ -53,13 +69,13 @@ namespace http {
 		return true;
 	}
 
-	std::map<std::string, std::string> Headers::getAll(void) const {
+	std::map<std::string, std::string, Headers::CaseInsensitive> Headers::getAll(void) const {
 		return this->_headers;
 	}
 	
 	// Get header value from key
 	std::string Headers::getHeader(const std::string &key) const {
-		std::map<std::string, std::string>::const_iterator it = _headers.find(key);
+		std::map<std::string, std::string, Headers::CaseInsensitive>::const_iterator it = _headers.find(key);
 		if (it != _headers.end())
 			return it->second;
 		return "";

--- a/src/http/Headers.hpp
+++ b/src/http/Headers.hpp
@@ -6,7 +6,7 @@
 /*   By: vcarrara <vcarrara@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/27 13:47:20 by vcarrara          #+#    #+#             */
-//   Updated: 2025/09/10 08:46:02 by maurodri         ###   ########.fr       //
+//   Updated: 2025/10/07 18:26:54 by maurodri         ###   ########.fr       //
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,6 +18,11 @@
 
 namespace http {
 	class Headers {
+		struct CaseInsensitive
+		{
+			bool operator()(const std::string &s1, const std::string &s2) const;
+		};
+
 		public:
 			Headers(void);
 			Headers(const Headers &other);
@@ -29,12 +34,12 @@ namespace http {
 			std::string getHeader(const std::string &key) const;
 			void clear(void);
 
-			std::map<std::string, std::string> getAll(void) const;
+			std::map<std::string, std::string, CaseInsensitive> getAll(void) const;
 
 			bool addHeader(const std::string &key, const std::string &value);
 			std::string str(void) const;
 		private:
-			std::map<std::string, std::string> _headers;
+			std::map<std::string, std::string, CaseInsensitive> _headers;
 	};
 }
 

--- a/src/http/Request.cpp
+++ b/src/http/Request.cpp
@@ -6,12 +6,11 @@
 /*   By: vcarrara <vcarrara@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/25 10:51:33 by vcarrara          #+#    #+#             */
-/*   Updated: 2025/10/07 01:12:46 by maurodri         ###   ########.fr       */
+//   Updated: 2025/10/07 19:28:46 by maurodri         ###   ########.fr       //
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "Request.hpp"
-#include "TcpClient.hpp"
 #include "BufferedReader.hpp"
 #include <sstream>
 #include <cstdlib>
@@ -114,7 +113,8 @@ namespace http
 			delete[] result.second;
 
 			if (line.empty()) { // End of Headers
-				std::string contentLength = _headers.getHeader("Content-Length");
+				std::string contentLength =
+					_headers.getHeader("Content-Length");
 				if (!contentLength.empty())
 					_state = READING_BODY; // Body to read
 				else

--- a/src/http/Response.cpp
+++ b/src/http/Response.cpp
@@ -6,7 +6,7 @@
 /*   By: vcarrara <vcarrara@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/09/02 13:22:28 by vcarrara          #+#    #+#             */
-//   Updated: 2025/10/01 19:16:50 by maurodri         ###   ########.fr       //
+//   Updated: 2025/10/07 17:55:29 by maurodri         ###   ########.fr       //
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -104,7 +104,7 @@ namespace http {
 		(*this)
 			.setStatusCode(404)
 			.setStatusInfo("Not Found")
-			.addHeader("Content-length", "0");
+			.addHeader("Content-Length", "0");
 		return *this;
 	}
 
@@ -113,7 +113,7 @@ namespace http {
 		(*this)
 			.setStatusCode(418)
 			.setStatusInfo("I'm a teapot")
-			.addHeader("Content-length", "0");
+			.addHeader("Content-Length", "0");
 		return *this;
 	}
 
@@ -122,7 +122,7 @@ namespace http {
 	    (*this)
 	        .setStatusCode(500)
 	        .setStatusInfo("Internal Server Error")
-	        .addHeader("Content-length", "0")
+	        .addHeader("Content-Length", "0")
 	        .addHeader("Connection", "Close");
 		return *this;
 	}
@@ -132,7 +132,7 @@ namespace http {
 		(*this)
 			.setStatusCode(400)
 			.setStatusInfo("Bad Request")
-			.addHeader("Content-length", "0");
+			.addHeader("Content-Length", "0");
 		return *this;
 	}
 
@@ -141,7 +141,7 @@ namespace http {
 		(*this)
 			.setStatusCode(201)
 			.setStatusInfo("Created")
-			.addHeader("Content-length", "0");
+			.addHeader("Content-Length", "0");
 		return *this;
 	}
 

--- a/src/http/Server.cpp
+++ b/src/http/Server.cpp
@@ -6,7 +6,7 @@
 /*   By: vcarrara <vcarrara@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/09/23 13:05:25 by vcarrara          #+#    #+#             */
-/*   Updated: 2025/10/07 00:59:30 by maurodri         ###   ########.fr       */
+//   Updated: 2025/10/07 19:00:04 by maurodri         ###   ########.fr       //
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -185,7 +185,9 @@ namespace http
 
 	void Server::onFileRead(http::Client &client, std::string fileContent)
 	{
+
 		client.getResponse()
+			.addHeader("Content-Type", "text/html") // TODO infer file type from extension
 			.setOk()
 			.setBody(fileContent);
 		client.setMessageToSend(client.getResponse().toString());
@@ -267,7 +269,6 @@ namespace http
 			return ;
 		}
 		std::cout << "clientFd = " << client.getFd() << std::endl;
-		// TODO: subscribe fd on EventLoop, maybe reuse reader from client
 		monitor.subscribeFileRead(fd, client.getFd());
 	}
 
@@ -317,6 +318,7 @@ namespace http
 		html << "</ul></body></html>";
 
 		response.setOk()
+			.addHeader("Content-Type", "text/html")
 			.setBody(html.str());
 		client.setMessageToSend(response.toString());
 	}

--- a/src/http/Server.hpp
+++ b/src/http/Server.hpp
@@ -6,7 +6,7 @@
 /*   By: vcarrara <vcarrara@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/09/23 13:00:29 by vcarrara          #+#    #+#             */
-//   Updated: 2025/10/02 01:20:35 by maurodri         ###   ########.fr       //
+//   Updated: 2025/10/07 17:38:02 by maurodri         ###   ########.fr       //
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,8 +47,7 @@ namespace http
 		Server &operator=(const Server &other);
 		virtual ~Server(void);
 
-		std::string getHostname() const
-;
+		std::string getHostname() const;
 		std::string getDocroot() const;
 
 		void addCgiRoute(const std::string &route);


### PR DESCRIPTION
request headers may have diferent casing and should still work, for example both `Content-Length` and `Content-length` should be treated the same.

With eww browser server was failing to retrieve content length from post request because eww was sending `Content-length` and server was looking for 'Content-Length' case sensitive.

On this pull I change all header key comparisions to be case insensitive by adding a comparator function on std::map that backs up the hearders